### PR TITLE
Create header component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
+    "react-tooltip": "^4.2.19",
     "web-vitals": "^1.0.1"
   },
   "scripts": {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,7 +6,8 @@ import {
 } from 'react-router-dom';
 
 // Local imports.
-import { Home } from 'components';
+import { Header, Home, Profile } from 'components';
+// import { Profile } from 'components/views/profile';
 
 const App = () => {
   // Get the current location.
@@ -14,13 +15,27 @@ const App = () => {
 
   // Return the app routes.
   return (
-    <Switch>
-      {/* If a route is accessed with a a trailing slash, redirect to
-      the route without the slash. */}
-      <Redirect from="/:url*(/+)" to={pathname.slice(0, -1)} />
-      <Route exact path="/" component={Home} />
-      {/* <Route exact path="/"><p>HOME PAGE</p></Route> */}
-    </Switch>
+    <div>
+      {/* Display the header on every page but the home page. Putting it here reduces
+      amount of times the header component is rendered. */}
+      <Route
+        path="/"
+        render={
+          ( props ) => (props.location.pathname !== "/") &&
+          <Header />
+        }
+      />
+      <Switch>
+        {/* If a route is accessed with a a trailing slash, redirect to
+        the route without the slash. */}
+        <Redirect from="/:url*(/+)" to={pathname.slice(0, -1)} />
+        <Route exact path="/" component={Home} />
+        {/* Holding spot for a profile page to test theme and header load */}
+        <Route path="/profile" component={Profile} />
+        {/* update with 404 page component */}
+        <Route><p>ERROR</p></Route>
+      </Switch>
+    </div>
   );
 }
 

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -2,8 +2,10 @@
 
 // This file imports and exports authorization components
 // and modules.
+import Header from 'components/theme/header';
 import Home from 'components/views/home';
 import Loading from 'components/theme/loading';
+import Profile from 'components/views/profile';
 
 // Exports.
-export { Home, Loading };
+export { Header, Home, Loading, Profile };

--- a/frontend/src/components/theme/header/header-components/index.js
+++ b/frontend/src/components/theme/header/header-components/index.js
@@ -1,0 +1,12 @@
+// ./src/components/theme/header/header-components/index.js
+
+// This file imports and exports authorization components
+// and modules.
+import NavLogo from 'components/theme/header/header-components/nav-logo';
+import NavLogoutButton from 'components/theme/header/header-components/nav-logout-button';
+import NavMenu from 'components/theme/header/header-components/nav-menu';
+
+// Exports.
+export {
+  NavLogo, NavLogoutButton, NavMenu,
+};

--- a/frontend/src/components/theme/header/header-components/nav-logo.jsx
+++ b/frontend/src/components/theme/header/header-components/nav-logo.jsx
@@ -1,0 +1,23 @@
+// ./src/components/theme/header/header-components/nav-logo.jsx
+
+// External package dependencies.
+import React from 'react';
+
+// Local imports.
+import {
+  NAV_LOGO_ALT_TEXT, NAV_LOGO_FILE, NAV_LOGO_SIZE
+} from 'components/theme/header/styles';
+
+// Define the Logo/Branded component of the navigation bar.
+const NavLogo = () => (
+
+    <img
+      // className="header-logo"
+      src={NAV_LOGO_FILE}
+      alt={NAV_LOGO_ALT_TEXT}
+      height={NAV_LOGO_SIZE}
+    />
+);
+
+// Export the NavLogo
+export default NavLogo;

--- a/frontend/src/components/theme/header/header-components/nav-logout-button.jsx
+++ b/frontend/src/components/theme/header/header-components/nav-logout-button.jsx
@@ -1,0 +1,43 @@
+// ./src/components/theme/header/header-components/nav-logout-button.jsx
+
+// External package dependencies.
+import React, {Fragment} from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { IconButton } from '@material-ui/core';
+import { ExitToApp } from '@material-ui/icons';
+import ReactTooltip from 'react-tooltip';
+
+// Local imports.
+import useStyles from 'components/theme/header/styles';
+
+// Create the homepage login button.
+const NavLogoutButton = (props) => {
+  // Setup the login action.
+  const { logout } =useAuth0();
+
+  // Setup the button classes.
+  const classes = useStyles();
+
+  // Define the login button and return it with
+  // the login action.
+  return (
+    <Fragment>
+      <ReactTooltip
+       place="bottom"
+       effect="solid"
+       delayShow={500}
+      />
+      <IconButton
+        edge="start"
+        color="inherit"
+        aria-label="logout"
+        onClick={() => logout()}
+      >
+        <ExitToApp data-tip="Logout" className={classes.navIconStyle} />
+      </IconButton>
+    </Fragment>
+  );
+};
+
+// Export the LogoutButton.
+export default NavLogoutButton;

--- a/frontend/src/components/theme/header/header-components/nav-menu.jsx
+++ b/frontend/src/components/theme/header/header-components/nav-menu.jsx
@@ -1,0 +1,61 @@
+// ./src/components/theme/header/headercomponents/nav-menu.jsx
+
+// External package imports.
+import React, { Fragment } from 'react';
+import { useHistory } from 'react-router-dom';
+import { IconButton } from '@material-ui/core';
+import { Home, PeopleAlt, Person, Theaters } from '@material-ui/icons';
+import ReactTooltip from 'react-tooltip';
+
+// Local imports.
+import useStyles from 'components/theme/header/styles';
+
+// Create the navigation menu component.
+const NavMenu = () => {
+  const classes = useStyles();
+  const history = useHistory();
+  return(
+    <Fragment>
+      <ReactTooltip
+        place="bottom"
+        effect="solid"
+        delayShow={500}
+      />
+      <IconButton
+        edge="start"
+        color="inherit"
+        aria-label="profile"
+        onClick={() => history.push("/profile")}
+      >
+        <Person data-tip="Profile" className={classes.navIconStyle} />
+      </IconButton>
+      <IconButton
+        edge="start"
+        color="inherit"
+        aria-label="movies"
+        onClick={() => history.push("/movies")}
+      >
+          <Theaters data-tip="Movies" className={classes.navIconStyle} />
+      </IconButton>
+      <IconButton
+        edge="start"
+        color="inherit"
+        aria-label="matches"
+        onClick={() => history.push("/matches")}
+      >
+        <PeopleAlt data-tip="Matches" className={classes.navIconStyle} />
+      </IconButton>
+      <IconButton
+        edge="start"
+        color="inherit"
+        aria-label="home"
+        onClick={() => history.push("/")}
+      >
+        <Home data-tip="Home" className={classes.navIconStyle} />
+      </IconButton>
+    </Fragment>
+  )
+}
+
+// Export the navigation menu.
+export default NavMenu;

--- a/frontend/src/components/theme/header/header.jsx
+++ b/frontend/src/components/theme/header/header.jsx
@@ -1,0 +1,53 @@
+// ./src/components/theme/header/header.jsx
+
+// External package dependencies.
+import React from 'react';
+import {
+  AppBar, Box, Grid, Toolbar,
+} from '@material-ui/core';
+
+// Local imports.
+import useStyles from 'components/theme/header/styles';
+import {
+  NavLogo, NavLogoutButton, NavMenu
+} from 'components/theme/header/header-components';
+
+// The main Navigation bar component.
+const Header = () => {
+  // Setup the classes.
+  const classes = useStyles();
+  // Return the main header component (navigation bar).
+  return (
+    // Define the NavBar with classes and add component elements.
+    <AppBar position="fixed" className={classes.applicationBar}>
+      <Toolbar>
+      <Grid container justify={"space-between"} alignItems="center">
+        <Grid item xs={false} sm={3} m={3}>
+          <Box
+            display={{
+              xs: 'none',
+              sm: 'block',
+            }}
+            align="left"
+          >
+            <NavLogo />
+          </Box>
+        </Grid>
+        <NavMenu  />
+        <Grid item xs={false} sm={3} md={3}>
+          <Box display={{
+           xs: 'none',
+            sm: 'block',
+          }} align='right'>
+            <NavLogoutButton />
+          </Box>
+        </Grid>
+      </Grid>
+      </Toolbar>
+    </AppBar>
+  );
+};
+
+
+// Export the NavBar.
+export default Header;

--- a/frontend/src/components/theme/header/index.js
+++ b/frontend/src/components/theme/header/index.js
@@ -1,0 +1,8 @@
+// ./src/components/theme/header/index.js
+
+// This file imports and exports authorization components
+// and modules.
+import Header from 'components/theme/header/header';
+
+// Exports.
+export default Header;

--- a/frontend/src/components/theme/header/styles/index.js
+++ b/frontend/src/components/theme/header/styles/index.js
@@ -1,0 +1,20 @@
+// ./src/components/theme/header/styles/index.js
+
+// This file imports and exports authorization components
+// and modules.
+
+// Import constants.
+import {
+  NAV_LOGO_ALT_TEXT, NAV_LOGO_FILE, NAV_LOGO_SIZE
+} from 'components/theme/header/styles/settings';
+
+// Import styles.
+import useStyles from 'components/theme/header/styles/styles';
+
+// Export constants.
+export {
+    NAV_LOGO_ALT_TEXT, NAV_LOGO_FILE, NAV_LOGO_SIZE
+}
+
+  // Export the styles.
+  export default useStyles;

--- a/frontend/src/components/theme/header/styles/settings.js
+++ b/frontend/src/components/theme/header/styles/settings.js
@@ -1,0 +1,10 @@
+// ./src/components/theme/header/settings.js
+
+// This file contains constants for elements of the header.
+
+// Logo image constants.
+export const NAV_LOGO_ALT_TEXT = `A movie camera facing left with a strip of
+  film extending to the edge on a purple background. Movies 'n Chill is
+  written in white below the strip of film.`;
+export const NAV_LOGO_FILE = `${process.env.PUBLIC_URL}/nav-logo.png`;
+export const NAV_LOGO_SIZE = `100px`;

--- a/frontend/src/components/theme/header/styles/styles.js
+++ b/frontend/src/components/theme/header/styles/styles.js
@@ -1,0 +1,54 @@
+// ./src/components/theme/header/styles/styles.js
+
+// External package dependencies.
+import { makeStyles }from '@material-ui/core/styles'
+
+export default makeStyles(theme => ({
+  applicationBar:{
+    boxShadow: 'none',
+  },
+  navIconStyle: {
+    height: '65px',
+    width: '65px',
+    '&:active': {
+      boxShadow: 'none',
+      outline: 0,
+      outlineStyle: 'none',
+      outlineWidth: 0,
+    },
+    '&:focus': {
+      boxShadow: 'none',
+      outline: 0,
+      outlineStyle: 'none',
+      outlineWidth: 0,
+    },
+  },
+}));
+
+// // Button constants.
+// const navBackgroundColor = `#923d87`;
+// // const highlightColor = `#662a5e`;
+// const textColor = `#FFFFFF`;
+
+// const useStyles = makeStyles({
+//   navBarDisplayFlex:{
+//     // display: 'flex',
+//     // justifyContent: 'space-between',
+//   },
+//   navDisplayFlex:{
+//     // display: 'flex',
+//     // // justifyContent: 'space-between',
+//     // flexDirection: 'row-reverse'
+//   },
+//   toolbarRight:{
+//     // marginLeft: 'auto',
+//     display: 'flex',
+//     justifyContent: 'space-between',
+//     // flexDirection: 'row-reverse'
+//   },
+//   linkText: {
+//     textDecoration: 'none',
+//     textTransform: 'uppercase',
+//     color: '#FFFFFF',
+//   },
+// });

--- a/frontend/src/components/views/home/home.jsx
+++ b/frontend/src/components/views/home/home.jsx
@@ -18,7 +18,7 @@ const Home = () => {
     isLoading ?
       <Loading />
     : isAuthenticated ?
-      <div><HomeMain /><p>AUTHENTICATED</p></div>
+      <Redirect to="/profile" />
     : <HomeMain />
   );
 };

--- a/frontend/src/components/views/profile/index.js
+++ b/frontend/src/components/views/profile/index.js
@@ -1,0 +1,8 @@
+// ./src/components/views/profile/index.js
+
+// This file imports and exports authorization components
+// and modules.
+import Profile from 'components/views/profile/profile';
+
+// Exports.
+export default Profile;

--- a/frontend/src/components/views/profile/profile.jsx
+++ b/frontend/src/components/views/profile/profile.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Box, Typography } from '@material-ui/core';
+
+const Profile = () => {
+    return(
+        <Box pt={15}>
+        <Typography>PROFILE PAGE GOES HERE</Typography>
+        </Box>
+    )
+}
+
+export default Profile;

--- a/frontend/src/styles/styles.js
+++ b/frontend/src/styles/styles.js
@@ -1,41 +1,36 @@
+// ./src/styles/styles.js
+
+// External package dependencies.
 import {
     createMuiTheme,
     responsiveFontSizes,
     makeStyles
   } from '@material-ui/core/styles';
 
-  let theme = createMuiTheme({
-    palette: {
-      primary: {
-        main: '#923d87'
-      },
-      secondary: {
-        main: '#008AB8'
-      },
-      background: '#FFE6FF',
-    }
-  });
-
-  theme = responsiveFontSizes(theme);
-
-  const useStyle = makeStyles(() => ({
-    root: {
-      width: '100%',
-      heigh: '100%',
-      backgroundColor: theme.palette.background,
-      color: theme.palette.text.primary
+// Create theme with colors.
+let theme = createMuiTheme({
+  palette: {
+    primary: {
+      main: '#923d87'
     },
-    // paper: {
-    //   marginTop: theme.spacing(3),
-    //   marginBottom: theme.spacing(3),
-    //   padding: theme.spacing(2),
-    //   [theme.breakpoints.up(600 + theme.spacing(3) * 2)]: {
-    //     marginTop: theme.spacing(6),
-    //     marginBottom: theme.spacing(6),
-    //     padding: theme.spacing(3)
-    //   }
-    // },
-  }));
+    secondary: {
+      main: '#008AB8'
+    },
+    background: '#FFE6FF',
+  },
+});
 
-  // Export the theme.
-  export { theme, useStyle };
+// Set the theme.
+theme = responsiveFontSizes(theme);
+
+const useStyle = makeStyles(() => ({
+  root: {
+    width: '100%',
+    minHeight: '100vh',
+    backgroundColor: theme.palette.background,
+    color: theme.palette.text.primary,
+  },
+}));
+
+// Export the theme.
+export { theme, useStyle };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10039,6 +10039,14 @@ react-scripts@4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
+react-tooltip@^4.2.19:
+  version "4.2.19"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.19.tgz#a865fffdb62154c6079bcb273e238de6b3c57366"
+  integrity sha512-wF6h0a2nqX3UHw9aSoj77Tv/+/KIjRdb107otHtX+1wISad1QoLD+j5chrBDx7mjY1T4WKfrV2DN+iFCimdZOw==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
 react-transition-group@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
@@ -11987,6 +11995,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuid@^8.3.0:
   version "8.3.2"


### PR DESCRIPTION
Created the header component for non-home page pages. Added this to
App.js to be rendered whenever the page is not the home page, which
should mean the header renders much less often then if it was
included in every view directly. Also added a placeholder for user
profile page to test the header and test redirect on Auth0
authorization.