### PR TITLE
Create 404 not found component, refactor header

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,14 +1,16 @@
 // ./src/app.js
 
 // External package dependencies.
+import React from 'react';
 import {
   Redirect, Route, Switch, useLocation,
 } from 'react-router-dom';
 
+
 // Local imports.
 import {
-  Header, Home, Matches,
-  Movies, Profile,
+  Home, Matches, Movies,
+  NotFound, Profile,
 } from 'components';
 import { ProtectedRoute } from 'auth';
 
@@ -18,16 +20,7 @@ const App = () => {
 
   // Return the app routes.
   return (
-    <div>
-      {/* Display the header on every page but the home page. Putting it here reduces
-      amount of times the header component is rendered. */}
-      <Route
-        path="/"
-        render={
-          ( props ) => (props.location.pathname !== "/") &&
-          <Header />
-        }
-      />
+    <>
       <Switch>
         {/* If a route is accessed with a a trailing slash, redirect to
         the route without the slash. */}
@@ -37,9 +30,9 @@ const App = () => {
         <ProtectedRoute path="/movies" component={Movies} />
         <ProtectedRoute path="/profile" component={Profile} />
         {/* update with 404 page component */}
-        <Route><p>ERROR</p></Route>
+        <ProtectedRoute component={NotFound} />
       </Switch>
-    </div>
+    </>
   );
 }
 

--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -8,10 +8,11 @@ import Home from 'components/views/home';
 import Loading from 'components/theme/loading';
 import Matches from 'components/views/matches';
 import Movies from 'components/views/movies';
+import NotFound from 'components/theme/not-found';
 import Profile from 'components/views/profile';
 
 // Exports.
 export {
   CenteredPage, Header, Home, Loading,
-  Matches, Movies, Profile
+  Matches, Movies, NotFound, Profile,
 };

--- a/frontend/src/components/theme/not-found/index.js
+++ b/frontend/src/components/theme/not-found/index.js
@@ -1,0 +1,6 @@
+// ./src/components/theme/page-not-found/index.js
+
+
+import NotFound from 'components/theme/not-found/not-found';
+
+export default NotFound;

--- a/frontend/src/components/theme/not-found/not-found.jsx
+++ b/frontend/src/components/theme/not-found/not-found.jsx
@@ -1,0 +1,42 @@
+// ./src/components/theme/page-not-found/page-not-found.jsx
+
+// External package dependencies.
+import React from 'react';
+import {
+ Grid, Typography
+} from '@material-ui/core';
+
+// Local imports.
+import { Header } from 'components';
+import useStyles, {
+  ERR_404, NOT_FOUND_TEXT
+} from 'components/theme/not-found/styles';
+
+const NotFound = () => {
+  const classes = useStyles();
+  return (
+    <>
+      <Header />
+      <Grid container className={classes.pageContainer}>
+        <Grid item xs={false} sm={2}></Grid>
+        <Grid item xs={12} sm={8}>
+          <Typography variant="h3" className={classes.errorLargeText} align="center">
+            {ERR_404}
+          </Typography>
+          <Grid container>
+          <Grid item xs={2}></Grid>
+          <Grid item xs={8}>
+          <Typography variant="h4" className={classes.errorText} align="center">
+            {NOT_FOUND_TEXT}
+          </Typography>
+          </Grid>
+          <Grid item xs={2}></Grid>
+          </Grid>
+        </Grid>
+        <Grid item xs={false} sm={2}></Grid>
+      </Grid>
+    </>
+    );
+  };
+
+export default NotFound;

--- a/frontend/src/components/theme/not-found/styles/index.js
+++ b/frontend/src/components/theme/not-found/styles/index.js
@@ -1,0 +1,16 @@
+// ./src/components/theme/page-not-found/styles/index.js
+
+// This file imports and exports authorization components
+// and modules.
+
+import { ERR_404, NOT_FOUND_TEXT } from 'components/theme/not-found/styles/settings';
+
+
+// Import styles.
+import useStyles from 'components/theme/not-found/styles/styles';
+
+// Export constants.
+export { ERR_404, NOT_FOUND_TEXT };
+
+// Export the styles.
+export default useStyles;

--- a/frontend/src/components/theme/not-found/styles/settings.js
+++ b/frontend/src/components/theme/not-found/styles/settings.js
@@ -1,0 +1,5 @@
+// .src/components/theme/page-not-found/styles/settings.js
+
+export const ERR_404 = `404`;
+export const NOT_FOUND_TEXT = `We're we're sorry! This page or resource` +
+                              ` was not found on our servers.`;

--- a/frontend/src/components/theme/not-found/styles/styles.js
+++ b/frontend/src/components/theme/not-found/styles/styles.js
@@ -1,0 +1,20 @@
+// ./src/components/theme/page-not-found/styles/styles.js
+
+// External package dependencies.
+import { makeStyles }from '@material-ui/core/styles'
+
+const errorTextColor = `#662a5e`
+const errorLargeColor = `#008AB8`;
+
+export default makeStyles(theme => ({
+  errorLargeText: {
+    color: errorLargeColor,
+    fontSize: '15rem',
+  },
+  errorText: {
+    color: errorTextColor,
+  },
+  pageContainer: {
+    minHeight: "100vh",
+  },
+}));

--- a/frontend/src/components/views/matches/matches.jsx
+++ b/frontend/src/components/views/matches/matches.jsx
@@ -5,19 +5,22 @@ import React from 'react';
 import { Box, Grid, Typography } from '@material-ui/core';
 
 // Local imports.
-import { CenteredPage } from 'components';
+import { CenteredPage, Header } from 'components';
 
 // This is the main matches page wrapper. It should determine
 // state, and display components appropriately.
 const Matches = () => (
-  <CenteredPage>
-    <Grid item xs={12} align="center">
-      <Typography variant="h2">MATCHES PAGE</Typography>
-    </Grid>
-    <Box mt={5}>
-      <Typography variant="h4">components go here</Typography>
-    </Box>
-  </CenteredPage>
+  <>
+    <Header />
+    <CenteredPage>
+      <Grid item xs={12} align="center">
+        <Typography variant="h2">MATCHES PAGE</Typography>
+      </Grid>
+      <Box mt={5}>
+        <Typography variant="h4">components go here</Typography>
+      </Box>
+    </CenteredPage>
+  </>
 );
 
 export default Matches;

--- a/frontend/src/components/views/movies/movies.jsx
+++ b/frontend/src/components/views/movies/movies.jsx
@@ -1,23 +1,25 @@
 // ./src/components/views/movies/movies.jsx
 
 // External package dependencies.
-import React from 'react';
 import { Box, Grid, Typography } from '@material-ui/core';
 
 // Local imports.
-import { CenteredPage } from 'components';
+import { CenteredPage, Header } from 'components';
 
 // This is the main movie page wrapper. It should determine
 // state, and display components appropriately.
 const Movies = () => (
-  <CenteredPage>
-    <Grid item xs={12} align="center">
-      <Typography variant="h2">MOVIES PAGE</Typography>
-    </Grid>
-    <Box mt={5}>
-      <Typography variant="h4">components go here</Typography>
-    </Box>
-  </CenteredPage>
+  <>
+    <Header />
+    <CenteredPage>
+      <Grid item xs={12} align="center">
+        <Typography variant="h2">MOVIES PAGE</Typography>
+      </Grid>
+      <Box mt={5}>
+        <Typography variant="h4">components go here</Typography>
+      </Box>
+    </CenteredPage>
+  </>
 );
 
 export default Movies;

--- a/frontend/src/components/views/profile/profile.jsx
+++ b/frontend/src/components/views/profile/profile.jsx
@@ -1,23 +1,25 @@
 // ./src/components/views/profile/profile.jsx
 
 // External package dependencies.
-import React from 'react';
 import {Box, Grid, Typography } from '@material-ui/core';
 
 // Local imports.
-import { CenteredPage } from 'components';
+import { CenteredPage, Header } from 'components';
 
 // This is the main profile page wrapper. It should determine
 // state, and display components appropriately.
 const Profile = () => (
-  <CenteredPage>
-    <Grid item xs={12} align="center">
-      <Typography variant="h2">PROFILE PAGE</Typography>
-    </Grid>
-    <Box mt={5}>
-      <Typography variant="h4">components go here</Typography>
-    </Box>
-  </CenteredPage>
+  <>
+    <Header />
+    <CenteredPage>
+      <Grid item xs={12} align="center">
+        <Typography variant="h2">PROFILE PAGE</Typography>
+      </Grid>
+      <Box mt={5}>
+        <Typography variant="h4">components go here</Typography>
+      </Box>
+    </CenteredPage>
+  </>
 );
 
 export default Profile;


### PR DESCRIPTION
Created a not found component for 404 errors; removed the check for
authentication to display header in App.js and instead opted for
rendering the header on pages that require it to avoid potential
issues with future pages that may or may not require the header.