### PR TITLE
Refactor NotFound component

### DIFF
--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -9,8 +9,10 @@ import Loading from 'components/theme/loading';
 import Matches from 'components/views/matches';
 import Movies from 'components/views/movies';
 import NotFound from 'components/theme/not-found';
+import { Error404 } from 'components/theme/not-found';
 import Profile from 'components/views/profile';
 export {
   CenteredPage, Header, Home, Loading,
-  Matches, Movies, NotFound, Profile,
+  Matches, Movies, NotFound, Error404,
+  Profile,
 };

--- a/frontend/src/components/theme/not-found/index.js
+++ b/frontend/src/components/theme/not-found/index.js
@@ -2,6 +2,11 @@
 
 // This file imports and exports the NotFound component.
 
+import { Error404 } from
+  'components/theme/not-found/not-found-components';
+
 import NotFound from 'components/theme/not-found/not-found';
+
+export { Error404 };
 
 export default NotFound;

--- a/frontend/src/components/theme/not-found/not-found-components/error-404.jsx
+++ b/frontend/src/components/theme/not-found/not-found-components/error-404.jsx
@@ -1,0 +1,38 @@
+// ./src/components/theme/not-found/not-found-components/error-404.jsx
+
+// External package dependencies.
+import React from 'react';
+import {
+ Grid, Typography
+} from '@material-ui/core';
+
+// Local imports.
+import useStyles, {
+  ERR_404, NOT_FOUND_TEXT
+} from 'components/theme/not-found/styles';
+
+const Error404 = () => {
+  const classes = useStyles();
+  return (
+    <Grid container className={classes.pageContainer}>
+    <Grid item xs={false} sm={2}></Grid>
+    <Grid item xs={12} sm={8}>
+        <Typography variant="h3" className={classes.errorLargeText} align="center">
+        {ERR_404}
+        </Typography>
+        <Grid container>
+        <Grid item xs={2}></Grid>
+        <Grid item xs={8}>
+        <Typography variant="h4" className={classes.errorText} align="center">
+        {NOT_FOUND_TEXT}
+        </Typography>
+        </Grid>
+        <Grid item xs={2}></Grid>
+        </Grid>
+    </Grid>
+    <Grid item xs={false} sm={2}></Grid>
+    </Grid>
+  );
+};
+
+export default Error404;

--- a/frontend/src/components/theme/not-found/not-found-components/index.js
+++ b/frontend/src/components/theme/not-found/not-found-components/index.js
@@ -1,0 +1,8 @@
+// ./src/components/theme/not-found/not-found-components/index.js
+
+// This file imports and exports the NotFound component.
+
+import Error404 from
+  'components/theme/not-found/not-found-components/error-404';
+
+export { Error404 };

--- a/frontend/src/components/theme/not-found/not-found.jsx
+++ b/frontend/src/components/theme/not-found/not-found.jsx
@@ -2,41 +2,17 @@
 
 // External package dependencies.
 import React from 'react';
-import {
- Grid, Typography
-} from '@material-ui/core';
 
 // Local imports.
-import { Header } from 'components';
-import useStyles, {
-  ERR_404, NOT_FOUND_TEXT
-} from 'components/theme/not-found/styles';
+import { Header, Error404 } from 'components';
 
 const NotFound = () => {
-  const classes = useStyles();
 
   // Create and return the 404 error page.
   return (
     <>
       <Header />
-      <Grid container className={classes.pageContainer}>
-        <Grid item xs={false} sm={2}></Grid>
-        <Grid item xs={12} sm={8}>
-          <Typography variant="h3" className={classes.errorLargeText} align="center">
-            {ERR_404}
-          </Typography>
-          <Grid container>
-          <Grid item xs={2}></Grid>
-          <Grid item xs={8}>
-          <Typography variant="h4" className={classes.errorText} align="center">
-            {NOT_FOUND_TEXT}
-          </Typography>
-          </Grid>
-          <Grid item xs={2}></Grid>
-          </Grid>
-        </Grid>
-        <Grid item xs={false} sm={2}></Grid>
-      </Grid>
+      <Error404 />
     </>
     );
   };


### PR DESCRIPTION
The NotFound component renders the Header component by default, which
works for non-existent endpoints but doesn't work for components that
may need to render the error due to missing data. Split off the error
portion of NotFound into its own component that can be rendered
without the Header.